### PR TITLE
outro修改为CommonJs规范优先

### DIFF
--- a/src/outro.js
+++ b/src/outro.js
@@ -1,13 +1,11 @@
-
+// CommonJs
+if (typeof exports === 'object' && typeof module !== 'undefined') {
+    module.exports = template;
 // RequireJS && SeaJS
-if (typeof define === 'function') {
+} else if (typeof define === 'function') {
     define(function() {
         return template;
     });
-
-// NodeJS
-} else if (typeof exports !== 'undefined') {
-    module.exports = template;
 } else {
     this.template = template;
 }


### PR DESCRIPTION
修改为CommonJs规范优先的原因是，在浏览器端，使用Commonjs规范加载art-template时，会默认包装一层define，如使用fis3的modjs，而这里之前是AMD规范优先，这就会导致CommonJs规范的代码也进入amd的定义逻辑中。